### PR TITLE
Do not create new handler function on every request

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -10,7 +10,7 @@ BasePath = "/opt/git-mirror/data"
 # An example of a public mirror taking defaults from above.  The Name is
 # generated from the URL by just taking the host and path.
 #
-# Will be mirrored at at http://localhost:8080/github.com/espressif/git-mirror-server.git
+# Will be mirrored at http://localhost:8080/github.com/espressif/git-mirror-server.git
 [[Repo]]
 Origin = "https://github.com/espressif/git-mirror-server.git"
 

--- a/main.go
+++ b/main.go
@@ -45,23 +45,17 @@ func main() {
 	}
 
 	// Set up git http-backend CGI handler
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// Set the required environment variables for git http-backend
-		env := []string{
+	gitBackend := &cgi.Handler{
+		Path: "/usr/bin/git",
+		Args: []string{"http-backend"},
+		Dir:  cfg.BasePath,
+		Env: []string{
 			"GIT_PROJECT_ROOT=" + cfg.BasePath,
 			"GIT_HTTP_EXPORT_ALL=true",
-		}
+		},
+	}
 
-		// Create a new CGI handler for git http-backend
-		gitBackend := &cgi.Handler{
-			Path: "/usr/bin/git",
-			Args: []string{"http-backend"},
-			Dir:  cfg.BasePath,
-			Env:  env,
-		}
-
-		gitBackend.ServeHTTP(w, r)
-	})
+	http.HandleFunc("/", gitBackend.ServeHTTP)
 
 	log.Printf("starting git HTTP server on %s", cfg.ListenAddr)
 	if err := http.ListenAndServe(cfg.ListenAddr, nil); err != nil {


### PR DESCRIPTION
<!--
- Read and understand the project style guidelines (`CONTRIBUTION.md`).
- For Work In Progress Pull Requests, please use the Draft PR feature. See https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
- For a timely review/response, please avoid force-pushing additional commits if your PR has already received reviews or comments.
- Include screenshots for any CLI or UI changes.
- Keep PRs as small as possible; large PRs are difficult to review.
-->

## Description


Do not create CGI handler function on every request

<!--
- Please include a summary of the changes and the related issue.
- Also include the motivation (why this change) and context.
-->

<!-- 
- If you want to insert images (screenshots, diagrams, etc.), please format them:
    Bad link to the image (not formatted):   ![image](https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d)~~
    Good link to the image (formatted):       <img src="https://github.com/user-attachments/assets/ad3383cd-8f38-4d06-9ecf-3305e299307d" width=500px>
-->

## Related

<!--
- Use this format to link issue numbers: Fixes #123 - https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue-using-a-keyword
- Mention any other PRs related to this one.
- If there is related documentation, add the link here.
- If there is a public chat where changes in this PR were initiated, you can include the link here.
-->

## Testing

<!--
- Explain how you tested your change or new feature.
- If you tested changes in a clean environment (Docker container, new virtualenv, fresh Virtual Machine), state it here.
-->

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
