### PR TITLE
feat: Limit number of concurrent connections

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,11 +16,12 @@ type duration struct {
 }
 
 type config struct {
-	ListenAddr     string
-	Interval       duration
-	BitmapInterval duration
-	BasePath       string
-	Repo           []repo
+	ListenAddr               string
+	Interval                 duration
+	BitmapInterval           duration
+	BasePath                 string
+	MaxConcurrentConnections int
+	Repo                     []repo
 }
 
 type repo struct {
@@ -61,6 +62,11 @@ func parseConfig(filename string) (cfg config, repos map[string]repo, err error)
 	}
 	if cfg.BasePath, err = filepath.Abs(cfg.BasePath); err != nil {
 		err = fmt.Errorf("unable to get absolute path to base path, %s", err)
+	}
+
+	// Set a default max concurrent connections if not specified
+	if cfg.MaxConcurrentConnections <= 0 {
+		cfg.MaxConcurrentConnections = 32
 	}
 
 	// Fetch repos, injecting default values where needed.

--- a/example-config.toml
+++ b/example-config.toml
@@ -10,6 +10,10 @@ BitmapInterval = "10h"
 # Base path for storing mirrors, absolute or relative.  Defaults to "."
 BasePath = "/opt/git-mirror/data"
 
+# MaxConcurrentConnections limits the number of concurrent HTTP connections.
+# Defaults to 32 if not specified.
+MaxConcurrentConnections = 32
+
 # An example of a public mirror taking defaults from above.  The Name is
 # generated from the URL by just taking the host and path.
 #

--- a/main.go
+++ b/main.go
@@ -70,7 +70,17 @@ func main() {
 		},
 	}
 
-	http.HandleFunc("/", gitBackend.ServeHTTP)
+	// Create a semaphore to limit concurrent connections
+	semaphore := make(chan struct{}, cfg.MaxConcurrentConnections)
+
+	// Wrap the handler with concurrent connection limiting
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// Acquire semaphore
+		semaphore <- struct{}{}
+		defer func() { <-semaphore }()
+
+		gitBackend.ServeHTTP(w, r)
+	})
 
 	log.Printf("starting git HTTP server on %s", cfg.ListenAddr)
 	if err := http.ListenAndServe(cfg.ListenAddr, nil); err != nil {


### PR DESCRIPTION
This pull request adds a feature to limit the maximum number of concurrent HTTP connections to the git-mirror-server. This prevents
the server from being overwhelmed by too many simultaneous requests, which could lead to resource exhaustion.

## Changes

• Added MaxConcurrentConnections field to the configuration struct
• Implemented connection limiting using a semaphore pattern with buffered channels
• Set default limit to 32 concurrent connections when not specified in config
• Updated example configuration file with documentation for the new setting

## Benefits

• Protects server from resource exhaustion under high load
• Allows administrators to configure connection limits based on their infrastructure
• Maintains good performance under normal conditions while preventing overload

## Configuration

Users can now specify the maximum concurrent connections in their config file:

MaxConcurrentConnections = 50  # Set to desired limit

If not specified, the server defaults to 32 concurrent connections. Setting this value to 0 or a negative number will also use the
default limit.
