### PR TITLE
Fix concurrent behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 git-mirror
 config.toml
+PLAN.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,83 +1,22 @@
 # AGENTS.md
 
-## Project Overview
+## Overview
 
-This is a simple Git mirror server written in Go that creates and serves read-only mirrors of Git repositories. The server uses Git's smart HTTP protocol via `git http-backend` to provide efficient repository access.
+Git mirror server in Go. Clones repos as `--mirror`, serves them via `git http-backend` (CGI), and updates them in background goroutines. Three files: `main.go` (server), `config.go` (TOML config), `mirror.go` (git operations).
 
-### Key Features
-- Creates read-only mirrors of Git repositories
-- Automatically updates mirrors at configurable intervals
-- Serves mirrors over HTTP using Git's smart protocol
-- Supports both HTTPS and SSH origin repositories
-- Docker support for easy deployment
-- Counter-based multi-pack and bitmap index generation for improved performance
-- Per-repository configuration for fetch intervals and index refresh frequencies
+## Development
 
-### Architecture
-The application consists of three main Go files:
-1. `main.go` - Entry point, HTTP server setup, and background update processes
-2. `config.go` - Configuration parsing from TOML files
-3. `mirror.go` - Git mirror operations (clone, update, bitmap generation)
+- Use red/green TDD: write failing tests first, then implement to make them pass
+- `go test && go vet ./... && gofmt -s -l .`
+- Keep `example-config.toml` in sync with config struct changes
+- Old config fields must be silently ignored (TOML decoder drops unknown keys) — log a deprecation warning instead of erroring
+- Update this AGENTS.md and README.md if you find information here outdated.
 
-## Contribution Guide for AI Agents
+## Key Constraints
 
-### Code Style
-- Follow existing Go conventions and formatting
-- Use lowercase for package-private functions (only capitalize when needed across packages)
-- Error messages should be clear and include relevant context
-- Logging should be informative but not excessive
+- All maintenance git operations (`commit-graph write`, `multi-pack-index write`) must be safe for concurrent HTTP readers — no deleting pack files. Never use `git repack -d` in the serving path.
+- Background goroutines run one per repo with no parallelism within a repo, but `git http-backend` serves concurrent reads on the same repo directory simultaneously.
 
-### Testing
-- Run `go test` to ensure existing tests pass
-- Run `go vet` to check for code issues
-- Run `gofmt` to ensure proper formatting
-- Test Docker image build process
+## Repository
 
-### Common Commands
-- `go build` - Build the application
-- `go run main.go config.toml` - Run with a config file
-- `go test` - Run tests
-- `go vet ./...` - Check for potential issues
-- `gofmt -s -l .` - Check code formatting
-
-### Git Workflow
-1. Create a feature branch from main
-2. Make focused changes for a single feature
-3. Ensure code compiles and runs correctly
-4. Update documentation as needed
-5. Commit with clear, descriptive messages
-6. Push and create a pull request
-
-### Docker Image Management
-- Docker images are published to espressif/git-mirror on DockerHub
-- Images are tagged with version numbers (e.g., v1.2.3)
-- Major.minor and major version tags are also created (e.g., v1.2, v1)
-- The latest tag is updated only on official releases
-- Pre-release versions (with suffixes) only get the exact version tag
-
-### Configuration Changes
-- Add new configuration options to the `config` struct in `config.go`
-- Set appropriate defaults in the `parseConfig` function
-- Update `example-config.toml` with documentation for new options
-- Ensure backward compatibility with existing configurations
-
-### Error Handling
-- Always check and handle errors appropriately
-- Log errors with sufficient context for debugging
-- Don't ignore errors from important operations like bitmap index generation
-- Use `fmt.Errorf` with context when returning errors
-
-### Background Processes
-- Mirror updates run in goroutines with configurable intervals
-- Multi-pack index and bitmap index operations are counter-based, running after a specific number of fetches
-- Each repo maintains its own fetch counter to trigger index refresh operations
-- Multi-pack index refreshes are lightweight and run more frequently (default: 0, disabled)
-- Bitmap index rebuilds involve full repacks and run less frequently (default: 0, disabled)
-- Both operations can be disabled per-repo by setting their interval to 0
-- Ensure proper synchronization when accessing shared resources (counters use mutexes)
-- Use semaphores or other synchronization primitives when limiting concurrent operations
-
-### Documentation Updates
-- Update README.md when adding significant features
-- Keep example configuration files up to date
-- Document new command-line options or behaviors
+This project is developed in https://github.com/espressif/git-mirror-server. Only create PRs to this repo.

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -19,7 +20,6 @@ type config struct {
 	ListenAddr               string
 	Interval                 duration
 	MultiPackIndexInterval   int
-	BitmapIndexInterval      int
 	BasePath                 string
 	MaxConcurrentConnections int
 	Repo                     []repo
@@ -30,7 +30,6 @@ type repo struct {
 	Origin                 string
 	Interval               duration
 	MultiPackIndexInterval int
-	BitmapIndexInterval    int
 }
 
 func (d *duration) UnmarshalText(text []byte) (err error) {
@@ -45,9 +44,17 @@ func parseConfig(filename string) (cfg config, repos map[string]repo, err error)
 		err = fmt.Errorf("unable to read config file %s, %s", filename, err)
 		return
 	}
-	if _, err = toml.Decode(string(raw), &cfg); err != nil {
+	md, err := toml.Decode(string(raw), &cfg)
+	if err != nil {
 		err = fmt.Errorf("unable to load config %s, %s", filename, err)
 		return
+	}
+
+	for _, key := range md.Undecoded() {
+		if key[len(key)-1] == "BitmapIndexInterval" {
+			log.Printf("warning: BitmapIndexInterval in %s is deprecated and has no effect; bitmap indexes are now managed via MultiPackIndexInterval using multi-pack-index", filename)
+			break
+		}
 	}
 
 	// Set defaults if required.
@@ -59,9 +66,6 @@ func parseConfig(filename string) (cfg config, repos map[string]repo, err error)
 	}
 	if cfg.MultiPackIndexInterval < 0 {
 		cfg.MultiPackIndexInterval = 0
-	}
-	if cfg.BitmapIndexInterval < 0 {
-		cfg.BitmapIndexInterval = 0
 	}
 	if cfg.BasePath == "" {
 		cfg.BasePath = "."
@@ -111,9 +115,6 @@ func parseConfig(filename string) (cfg config, repos map[string]repo, err error)
 		}
 		if r.MultiPackIndexInterval < 0 {
 			r.MultiPackIndexInterval = cfg.MultiPackIndexInterval
-		}
-		if r.BitmapIndexInterval < 0 {
-			r.BitmapIndexInterval = cfg.BitmapIndexInterval
 		}
 		repos[r.Name] = r
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseConfigDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`
+[[Repo]]
+Origin = "https://example.com/repo.git"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, repos, err := parseConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("parseConfig failed: %s", err)
+	}
+
+	if cfg.MultiPackIndexInterval != 0 {
+		t.Errorf("expected default MultiPackIndexInterval=0, got %d", cfg.MultiPackIndexInterval)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+}
+
+func TestParseConfigWarnsOnDeprecatedBitmapIndexInterval(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`
+BitmapIndexInterval = 50
+
+[[Repo]]
+Origin = "https://example.com/repo.git"
+BitmapIndexInterval = 25
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := parseConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("parseConfig failed: %s", err)
+	}
+
+	if !strings.Contains(buf.String(), "BitmapIndexInterval") {
+		t.Fatal("expected deprecation warning for BitmapIndexInterval")
+	}
+}
+
+func TestParseConfigNoWarningWithoutDeprecatedFields(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(cfgPath, []byte(`
+[[Repo]]
+Origin = "https://example.com/repo.git"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := parseConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("parseConfig failed: %s", err)
+	}
+
+	if strings.Contains(buf.String(), "BitmapIndexInterval") {
+		t.Fatal("unexpected deprecation warning when BitmapIndexInterval is not set")
+	}
+}

--- a/example-config.toml
+++ b/example-config.toml
@@ -7,12 +7,10 @@ ListenAddr = ":8080"
 Interval = "15m"
 
 # MultiPackIndexInterval is the number of fetches after which to refresh the
-# multi-pack index. Disabled by default (0). Can be overridden per repo.
+# multi-pack-index with bitmap. This is safe for concurrent readers (atomic
+# file replacement, no pack deletion). Disabled by default (0).
+# Can be overridden per repo.
 MultiPackIndexInterval = 10
-
-# BitmapIndexInterval is the number of fetches after which to rebuild the
-# bitmap index with full repack. Disabled by default (0). Can be overridden per repo.
-BitmapIndexInterval = 50
 
 # Base path for storing mirrors, absolute or relative.  Defaults to "."
 BasePath = "/opt/git-mirror/data"
@@ -36,4 +34,3 @@ Origin = "git@github.com:toml-lang/toml.git"
 # Optional: Override default intervals for this specific repo
 # Interval = "10m"
 # MultiPackIndexInterval = 5
-# BitmapIndexInterval = 25

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/kumekay/git-mirror
 
-go 1.13
+go 1.22
 
 require github.com/BurntSushi/toml v0.4.1

--- a/mirror.go
+++ b/mirror.go
@@ -57,21 +57,17 @@ func mirror(cfg config, r repo) (string, error) {
 		return "", fmt.Errorf("failed to stat %s, %s", repoPath, err)
 	}
 
-	// Check if we need to run multi-pack index
+	// Commit-graph is cheap and safe to run after every fetch
+	if err := refreshCommitGraph(cfg, r); err != nil {
+		log.Printf("error refreshing commit-graph for %s: %s", r.Name, err)
+	}
+
+	// Multi-pack-index with bitmap runs every N fetches
 	if r.MultiPackIndexInterval > 0 && counter.fetchCount%uint64(r.MultiPackIndexInterval) == 0 {
 		if err := refreshMultiPackIndex(cfg, r); err != nil {
 			log.Printf("error refreshing multi-pack index for %s: %s", r.Name, err)
 		} else {
 			log.Printf("successfully refreshed multi-pack index for %s (fetch #%d)", r.Name, counter.fetchCount)
-		}
-	}
-
-	// Check if we need to run bitmap index
-	if r.BitmapIndexInterval > 0 && counter.fetchCount%uint64(r.BitmapIndexInterval) == 0 {
-		if err := refreshBitmapIndex(cfg, r); err != nil {
-			log.Printf("error refreshing bitmap index for %s: %s", r.Name, err)
-		} else {
-			log.Printf("successfully refreshed bitmap index for %s (fetch #%d)", r.Name, counter.fetchCount)
 		}
 	}
 
@@ -83,21 +79,19 @@ func mirror(cfg config, r repo) (string, error) {
 	return outStr, nil
 }
 
-// Rebuild git bitmap index for the repo to speed up fetches once in a while
-func refreshBitmapIndex(cfg config, r repo) error {
+func refreshCommitGraph(cfg config, r repo) error {
 	repoPath := path.Join(cfg.BasePath, r.Name)
 
-	// Run git repack with bitmap index
-	repackCmd := exec.Command("git", "repack", "-Ad", "--write-bitmap-index", "--pack-kept-objects")
-	repackCmd.Dir = repoPath
-	if out, err := repackCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to repack %s: %s, output: %s", repoPath, err, string(out))
+	cmd := exec.Command("git", "commit-graph", "write", "--reachable")
+	cmd.Dir = repoPath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to write commit-graph for %s: %s, output: %s", repoPath, err, string(out))
 	}
 
 	return nil
 }
 
-// Quickly write multi-pack-index with bitmap without full repack
+// Write multi-pack-index with bitmap across all packs without full repack
 func refreshMultiPackIndex(cfg config, r repo) error {
 	repoPath := path.Join(cfg.BasePath, r.Name)
 

--- a/mirror_test.go
+++ b/mirror_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func gitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=Test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=Test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s failed: %s\n%s", args, dir, err, out)
+	}
+}
+
+func setupTestEnv(t *testing.T) (srcDir string, cfg config, r repo) {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	srcDir = filepath.Join(tmpDir, "source")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, srcDir, "init", "-b", "main")
+	gitCmd(t, srcDir, "commit", "--allow-empty", "-m", "initial")
+
+	cfg = config{BasePath: filepath.Join(tmpDir, "mirrors")}
+	r = repo{
+		Name:                   "test-repo",
+		Origin:                 srcDir,
+		Interval:               duration{time.Second},
+		MultiPackIndexInterval: 1,
+	}
+
+	resetCounters()
+	return
+}
+
+func resetCounters() {
+	repoCountersMu.Lock()
+	repoCounters = make(map[string]*repoCounter)
+	repoCountersMu.Unlock()
+}
+
+func TestRefreshCommitGraph(t *testing.T) {
+	srcDir, cfg, r := setupTestEnv(t)
+	bareDir := filepath.Join(cfg.BasePath, r.Name)
+	if err := os.MkdirAll(filepath.Dir(bareDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, filepath.Dir(bareDir), "clone", "--mirror", srcDir, bareDir)
+
+	if err := refreshCommitGraph(cfg, r); err != nil {
+		t.Fatalf("refreshCommitGraph failed: %s", err)
+	}
+
+	cgPath := filepath.Join(bareDir, "objects", "info", "commit-graph")
+	if _, err := os.Stat(cgPath); os.IsNotExist(err) {
+		t.Fatal("commit-graph file was not created")
+	}
+}
+
+func TestRefreshMultiPackIndex(t *testing.T) {
+	srcDir, cfg, r := setupTestEnv(t)
+	bareDir := filepath.Join(cfg.BasePath, r.Name)
+	if err := os.MkdirAll(filepath.Dir(bareDir), 0755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, filepath.Dir(bareDir), "clone", "--mirror", srcDir, bareDir)
+	// Repack loose objects into a pack file so MIDX has something to index
+	gitCmd(t, bareDir, "repack", "-d")
+
+	if err := refreshMultiPackIndex(cfg, r); err != nil {
+		t.Fatalf("refreshMultiPackIndex failed: %s", err)
+	}
+
+	midxPath := filepath.Join(bareDir, "objects", "pack", "multi-pack-index")
+	if _, err := os.Stat(midxPath); os.IsNotExist(err) {
+		t.Fatal("multi-pack-index file was not created")
+	}
+}
+
+func TestMirrorCreatesCommitGraphOnUpdate(t *testing.T) {
+	srcDir, cfg, r := setupTestEnv(t)
+
+	// First call: clone
+	if _, err := mirror(cfg, r); err != nil {
+		t.Fatalf("initial mirror failed: %s", err)
+	}
+
+	// Add commit to source
+	gitCmd(t, srcDir, "commit", "--allow-empty", "-m", "second")
+
+	// Second call: update
+	if _, err := mirror(cfg, r); err != nil {
+		t.Fatalf("mirror update failed: %s", err)
+	}
+
+	bareDir := filepath.Join(cfg.BasePath, r.Name)
+	cgPath := filepath.Join(bareDir, "objects", "info", "commit-graph")
+	if _, err := os.Stat(cgPath); os.IsNotExist(err) {
+		t.Fatal("commit-graph was not created after mirror update")
+	}
+}
+
+func TestMirrorMultiPackIndexOnInterval(t *testing.T) {
+	srcDir, cfg, r := setupTestEnv(t)
+	r.MultiPackIndexInterval = 2
+
+	// Clone
+	if _, err := mirror(cfg, r); err != nil {
+		t.Fatalf("initial mirror failed: %s", err)
+	}
+
+	bareDir := filepath.Join(cfg.BasePath, r.Name)
+	// Repack loose objects so MIDX has pack files to index
+	gitCmd(t, bareDir, "repack", "-d")
+	midxPath := filepath.Join(bareDir, "objects", "pack", "multi-pack-index")
+
+	// First update (fetchCount=0, 0%2==0 → writes MIDX)
+	gitCmd(t, srcDir, "commit", "--allow-empty", "-m", "second")
+	if _, err := mirror(cfg, r); err != nil {
+		t.Fatalf("mirror update 1 failed: %s", err)
+	}
+	if _, err := os.Stat(midxPath); os.IsNotExist(err) {
+		t.Fatal("multi-pack-index should exist after first update (fetchCount=0)")
+	}
+
+	// Remove MIDX to verify it's NOT recreated on next update
+	if err := os.Remove(midxPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second update (fetchCount=1, 1%2!=0 → should NOT write MIDX)
+	gitCmd(t, srcDir, "commit", "--allow-empty", "-m", "third")
+	if _, err := mirror(cfg, r); err != nil {
+		t.Fatalf("mirror update 2 failed: %s", err)
+	}
+	if _, err := os.Stat(midxPath); !os.IsNotExist(err) {
+		t.Fatal("multi-pack-index should NOT exist after second update (fetchCount=1)")
+	}
+}


### PR DESCRIPTION
Closes #14

## Summary

- Replace `git repack -Ad --write-bitmap-index` with `git commit-graph write --reachable` (every fetch) and `git multi-pack-index write --bitmap` (every N fetches). Both operations are atomic (temp file + rename) and never delete pack files, making them safe to run while `git http-backend` serves concurrent clones/fetches.
- Remove `BitmapIndexInterval` config option (old configs with this field log a deprecation warning).

## Motivation

The previous `git repack -Ad` approach deleted pack files as part of consolidation. When a client was mid-clone via `git http-backend`, the pack file it was reading could be deleted, causing corrupt or failed clones. This was a race condition between the background maintenance goroutine and the HTTP serving path, with no locking between them.

The new approach provides equivalent read performance (commit-graph speeds up graph walks, MIDX bitmap speeds up object enumeration) without ever deleting files that concurrent readers depend on.

## Test plan

- [x] `TestRefreshCommitGraph` — verifies commit-graph file is created
- [x] `TestRefreshMultiPackIndex` — verifies multi-pack-index file is created
- [x] `TestMirrorCreatesCommitGraphOnUpdate` — verifies mirror() writes commit-graph after update
- [x] `TestMirrorMultiPackIndexOnInterval` — verifies MIDX respects the interval counter
- [x] `TestParseConfigDefaults` — verifies config parsing with new defaults
- [x] `TestParseConfigWarnsOnDeprecatedBitmapIndexInterval` — verifies deprecation warning
- [x] `TestParseConfigNoWarningWithoutDeprecatedFields` — no false warnings
- [ ] Deploy and verify clone throughput under concurrent load