### PR TITLE
Fix zombie process accumulation with process groups and periodic reaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The docker image is available on Docker Hub [espressif/git-mirror](https://hub.d
 You can run it with docker:
 
 ```
-docker run --rm -ti -v /your_config/path:/config espressif/git-mirror /config/config.toml
+docker run --rm --init -ti -v /your_config/path:/config espressif/git-mirror /config/config.toml
 ```
 
 Or with docker compose, for example:
@@ -53,6 +53,7 @@ Or with docker compose, for example:
 services:
   git-mirror:
     image: espressif/git-mirror
+    init: true
     ports:
       - "8080:8080"
     command: ["/etc/git-mirror/config.toml"]


### PR DESCRIPTION
## Summary

- use Docker's `--init` flag which uses https://github.com/krallin/tini under the hood to kill zombies

## Root cause

PR #22 correctly identified a race between the SIGCHLD handler and `os/exec.Cmd.Wait()`, but removing the handler entirely left no mechanism to reap orphaned grandchildren. When `CommandContext` kills a git process on context cancellation, its child helpers (like `git-remote-https`) get reparented to PID 1 (the Go server in Docker). Without a reaper, these accumulate as zombies until `fork()` fails with `EAGAIN`:

```
error: cannot fork() for remote-https: Resource temporarily unavailable
error: cannot fork() for upload-pack: Resource temporarily unavailable
```